### PR TITLE
Fix for Windows cannot change chinese

### DIFF
--- a/src/utils/applyChangeToValue.js
+++ b/src/utils/applyChangeToValue.js
@@ -36,7 +36,11 @@ const applyChangeToValue = (
   // handling for Backspace key with no range selection
   let spliceStart = Math.min(selectionStartBefore, selectionEndAfter)
 
-  let spliceEnd = selectionEndBefore
+  // fix for Windows cannot change chinese
+  let spliceEnd = oldPlainTextValue.lastIndexOf(
+    plainTextValue.substring(selectionEndAfter)
+  )
+
   if (selectionStartBefore === selectionEndAfter) {
     // handling for Delete key with no range selection
     spliceEnd = Math.max(selectionEndBefore, selectionStartBefore + lengthDelta)


### PR DESCRIPTION
What did you change (functionally and technically)?
Fix for Windows cannot change Chinese

before: https://i.imgur.com/B0aC6cE.gifv
after: https://i.imgur.com/UmmEtuu.gifv